### PR TITLE
fix: Enable related_books in blog API responses for all requests

### DIFF
--- a/backend/getBlogs.php
+++ b/backend/getBlogs.php
@@ -117,15 +117,13 @@ function getAllBlogs($db) {
         // Format blogs data
         $formatted_blogs = array_map('formatBlog', $blogs);
         
-        // Load related books for admin requests
-        if ($is_admin_request) {
-            foreach ($formatted_blogs as &$blog) {
-                $books_query = "SELECT * FROM related_books WHERE blog_id = :blog_id ORDER BY id ASC";
-                $books_stmt = $db->prepare($books_query);
-                $books_stmt->bindParam(':blog_id', $blog['id'], PDO::PARAM_INT);
-                $books_stmt->execute();
-                $blog['related_books'] = $books_stmt->fetchAll(PDO::FETCH_ASSOC);
-            }
+        // Load related books for ALL requests (not just admin)
+        foreach ($formatted_blogs as &$blog) {
+            $books_query = "SELECT * FROM related_books WHERE blog_id = :blog_id ORDER BY id ASC";
+            $books_stmt = $db->prepare($books_query);
+            $books_stmt->bindParam(':blog_id', $blog['id'], PDO::PARAM_INT);
+            $books_stmt->execute();
+            $blog['related_books'] = $books_stmt->fetchAll(PDO::FETCH_ASSOC);
         }
         
         $response = [
@@ -269,7 +267,8 @@ function formatBlog($blog) {
         'status' => $blog['status'],
         'view_count' => (int)$blog['view_count'],
         'created_at' => $blog['created_at'],
-        'updated_at' => $blog['updated_at']
+        'updated_at' => $blog['updated_at'],
+        'related_books' => [] // Will be populated later if needed
     ];
 }
 ?>


### PR DESCRIPTION
- Fixed issue where related_books field was only populated for admin requests
- Modified getAllBlogs() function to fetch related books for ALL blog requests
- Updated formatBlog() function to include related_books field in response structure
- Now all blog API endpoints properly return related books data with:
  * Book title, author, description, price
  * Purchase links and cover image URLs
  * Complete book metadata

Resolves empty related_books array issue in frontend blog displays.